### PR TITLE
Bug with postboxes collapse

### DIFF
--- a/js/postboxes.js
+++ b/js/postboxes.js
@@ -1,4 +1,7 @@
 jQuery(document).ready(function() {
 	jQuery(".if-js-closed").removeClass("if-js-closed").addClass("closed");
-	if (typeof(postboxes) !== "undefined") { postboxes.add_postbox_toggles("settings_page_snow-storm"); }
+	//checking for pagenow assure that the toggle is added only on that page!
+	if (typeof(postboxes) !== "undefined" && pagenow=="settings_page_snow-storm") { 
+    		postboxes.add_postbox_toggles(pagenow); 
+    	}
 });


### PR DESCRIPTION
After activated the plugin I cannot open anymore any postbox metaboxes
the action in triggered but the class "closed" is never removed

Tested with WP 4.7
and with all others plugin disabled

this small change fixes the issue for me